### PR TITLE
Add settings to hide comments and notifications

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -11,13 +11,13 @@
 
 /* Credit:  https://github.com/lawrencehook/remove-youtube-suggestions */
 
-"use strict";
+'use strict';
 
 // Config custom settings here
 const SETTINGS = {
   /// homepage redirect ///
   // redirectHomepage Options: 'wl', 'subs', 'lib', false
-  redirectHomepage: "wl",
+  redirectHomepage: 'wl',
   hideHomepage: true,
 
   /// video player ///
@@ -40,35 +40,35 @@ const SETTINGS = {
 
 // Mark settings in HTML
 const HTML = document.documentElement;
-Object.keys(SETTINGS).forEach((key) => {
+Object.keys(SETTINGS).forEach(key => {
   HTML.setAttribute(key, SETTINGS[key]);
 });
 
 // CSS selectors of elements to block
 const DESKTOP_BLOCK_LIST = [
-  // Ads
-  "#masthead-ad",
-  "ytd-mealbar-promo-renderer",
-  "ytd-carousel-ad-renderer",
-  ".ytd-display-ad-renderer",
-  "ytd-ad-slot-renderer",
-  "div.ytp-ad-overlay-image",
-  ".iv-branding.annotation-type-custom.annotation",
+  // Ads 
+  '#masthead-ad',
+  'ytd-mealbar-promo-renderer',
+  'ytd-carousel-ad-renderer',
+  '.ytd-display-ad-renderer',
+  'ytd-ad-slot-renderer',
+  'div.ytp-ad-overlay-image',
+  '.iv-branding.annotation-type-custom.annotation',
 
   // Shorts
   'html[hideShorts="true"] ytd-rich-section-renderer',
   'html[hideShorts="true"] ytd-reel-shelf-renderer',
   'html[hideShorts="true"] ytd-shelf-renderer',
 
-  // Left Bar Navigation
+  // Left Bar Navigation 
   'a[href="/feed/trending"]',
   'a[href="/feed/explore"]',
   'html[hideShorts="true"] ytd-guide-section-renderer a[title="Shorts"]',
   'html[hideShorts="true"] ytd-mini-guide-entry-renderer[aria-label="Shorts"]',
-  "ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(4)",
-  "ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(3)",
+  'ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(4)',
+  'ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(3)',
 
-  // Homepage
+  // Homepage 
   'html[hideHomepage="true"] a:not(#logo)[href="/"]',
   'html[hideHomepage="true"] ytd-browse[page-subtype="home"]',
 
@@ -83,22 +83,22 @@ const DESKTOP_BLOCK_LIST = [
   'html[hideComments="true"] ytd-comments#comments',
   // '#movie_player button.ytp-button.ytp-share-button',
   // '#movie_player button.ytp-button.ytp-watch-later-button',
-  ".ytd-download-button-renderer.style-scope",
+  '.ytd-download-button-renderer.style-scope',
 
   // Search
-  "div.sbdd_a",
-  "#container.ytd-search ytd-search-pyv-renderer",
+  'div.sbdd_a',
+  '#container.ytd-search ytd-search-pyv-renderer',
   'html[hideSearchButton="true"] div.ytd-masthead>ytd-searchbox',
   'html[hideSearchButton="true"] div.ytd-masthead>#voice-search-button',
   'html[hideNotifications="true"] ytd-notification-topbar-button-renderer',
 ];
 
 const MOBILE_BLOCK_LIST = [
-  // Ads
-  "ytm-companion-ad-renderer",
-  "ytm-promoted-sparkles-web-renderer",
+  // Ads 
+  'ytm-companion-ad-renderer',
+  'ytm-promoted-sparkles-web-renderer',
 
-  // Homepage
+  // Homepage 
   'html[hideHomepage="true"] div[tab-identifier="FEwhat_to_watch"]',
   'html[hideSearchButton="true"] #header-bar > header > div > button',
   'html[hideSearchButton="true"] #center.style-scope.ytd-masthead',
@@ -106,30 +106,26 @@ const MOBILE_BLOCK_LIST = [
   // Shorts in search results
   'html[hideShorts="true"] ytm-reel-shelf-renderer.item',
 
-  // Video Player
+  // Video Player 
   'html[hideRelatedVideos="true"] ytm-item-section-renderer[section-identifier="related-items"]>lazy-list',
   'html[hidePlayNextButton="true"] .player-controls-middle-core-buttons > div:nth-child(1)',
   'html[hidePlayNextButton="true"] .player-controls-middle-core-buttons > div:nth-child(5)',
 
-  // Navigation Bar
+  // Navigation Bar 
   'html[hideHomepage="true"] ytm-pivot-bar-item-renderer:nth-child(1)',
   'html[hideShorts="true"] ytm-pivot-bar-item-renderer:nth-child(2)',
   'ytm-chip-cloud-chip-renderer[chip-style="STYLE_EXPLORE_LAUNCHER_CHIP"]',
 ];
 
 // Add CSS to block elements
-let css = "";
-if (location.hostname.startsWith("www.")) {
-  css = DESKTOP_BLOCK_LIST.map((e) => `${e} {display: none !important}`).join(
-    "\n",
-  );
+let css = '';
+if (location.hostname.startsWith('www.')) {
+  css = DESKTOP_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
 }
-if (location.hostname.startsWith("m.")) {
-  css = MOBILE_BLOCK_LIST.map((e) => `${e} {display: none !important}`).join(
-    "\n",
-  );
+if (location.hostname.startsWith('m.')) {
+  css = MOBILE_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
 }
-const style = document.createElement("style");
+const style = document.createElement('style');
 style.textContent = css;
 document.head.appendChild(style);
 
@@ -138,6 +134,7 @@ let lastUrl = null;
 
 // Start running dynamic settings
 runDynamicSettings();
+
 
 ///// Dynamic Settings Functions /////
 
@@ -160,41 +157,37 @@ function runDynamicSettings() {
 }
 
 function redirectHomepage() {
-  if (location.pathname == "/") {
-    if (SETTINGS.redirectHomepage == "wl") {
-      location.replace("/playlist/?list=WL");
+  if (location.pathname == '/') {
+    if (SETTINGS.redirectHomepage == 'wl') {
+      location.replace('/playlist/?list=WL');
     }
-    if (SETTINGS.redirectHomepage == "subs") {
-      location.replace("/feed/subscriptions");
+    if (SETTINGS.redirectHomepage == 'subs') {
+      location.replace('/feed/subscriptions');
     }
-    if (SETTINGS.redirectHomepage == "lib") {
-      location.replace("/feed/library");
+    if (SETTINGS.redirectHomepage == 'lib') {
+      location.replace('/feed/library');
     }
   }
 }
 
 function redirectShortsPlayer() {
-  if (location.pathname.startsWith("/shorts")) {
-    const redirPath = location.pathname.replace("shorts", "watch");
+  if (location.pathname.startsWith('/shorts')) {
+    const redirPath = location.pathname.replace('shorts', 'watch');
     location.replace(redirPath);
   }
 }
 
 function disableRelatedAutoPlay() {
   // turn off auto play button
-  const autoplayButton = document.querySelectorAll(
-    ".ytp-autonav-toggle-button[aria-checked=true]",
-  );
-  autoplayButton?.forEach((e) => {
+  const autoplayButton = document.querySelectorAll('.ytp-autonav-toggle-button[aria-checked=true]');
+  autoplayButton?.forEach(e => {
     if (e && e.offsetParent) {
       e.click();
     }
   });
   // turn off auto play button on mobile
-  const mAutoplayButton = document.querySelectorAll(
-    ".ytm-autonav-toggle-button-container[aria-pressed=true]",
-  );
-  mAutoplayButton?.forEach((e) => {
+  const mAutoplayButton = document.querySelectorAll('.ytm-autonav-toggle-button-container[aria-pressed=true]');
+  mAutoplayButton?.forEach(e => {
     if (e && e.offsetParent) {
       e.click();
     }
@@ -203,47 +196,45 @@ function disableRelatedAutoPlay() {
 
 function hideShortsVideos() {
   const shortsLinks = document.querySelectorAll('a[href^="/shorts"]');
-  if (location.pathname == "/feed/subscriptions") {
-    shortsLinks.forEach((link) => {
+  if (location.pathname == '/feed/subscriptions') {
+    shortsLinks.forEach(link => {
       // For desktop
-      link.closest("ytd-video-renderer")?.remove();
+      link.closest('ytd-video-renderer')?.remove();
       // For mobile
-      link.closest("ytm-item-section-renderer")?.remove();
+      link.closest('ytm-item-section-renderer')?.remove();
     });
   }
   // Hide shorts on search result pages
-  if (location.pathname.startsWith("/results")) {
-    shortsLinks.forEach((link) => {
+  if (location.pathname.startsWith('/results')) {
+    shortsLinks.forEach(link => {
       // For desktop
-      link.closest("ytd-video-renderer")?.remove();
+      link.closest('ytd-video-renderer')?.remove();
       // For mobile
-      link.closest("ytm-video-with-context-renderer")?.remove();
+      link.closest('ytm-video-with-context-renderer')?.remove();
     });
   }
   // Hide the "shorts" tab on channel page
-  if (location.pathname.startsWith("/@")) {
-    document.querySelectorAll("div.tab-content")?.forEach((tab) => {
+  if (location.pathname.startsWith('/@')) {
+    document.querySelectorAll('div.tab-content')?.forEach(tab => {
       if (tab.innerText == "SHORTS") tab.parentElement.remove(); // desktop
     });
-    document.querySelectorAll('a[role="tab"]')?.forEach((tab) => {
-      if (tab.innerText == "SHORTS") tab.remove(); // mobile
+    document.querySelectorAll('a[role="tab"]')?.forEach(tab => {
+      if (tab.innerText == 'SHORTS') tab.remove(); // mobile
     });
   }
 }
 
 function skipVideoAds() {
-  if (location.pathname.startsWith("/watch")) {
+  if (location.pathname.startsWith('/watch')) {
     // click "skip ad" button if it exists
     // during the first 5s, th button is not clickable in UI, but it's clickable in console
-    const adSkipButton = document.querySelector(
-      ".ytp-ad-skip-button-slot button,.ytp-ad-overlay-close-button",
-    );
+    const adSkipButton = document.querySelector(".ytp-ad-skip-button-slot button,.ytp-ad-overlay-close-button");
     adSkipButton?.click();
 
     // skip ad video
-    const adVideo = document.querySelector(".ad-showing");
+    const adVideo = document.querySelector('.ad-showing');
     if (adVideo) {
-      const video = document.querySelector(".html5-main-video");
+      const video = document.querySelector('.html5-main-video');
       if (video && !isNaN(video?.duration)) {
         video.play();
         video.currentTime = video?.duration;
@@ -253,17 +244,13 @@ function skipVideoAds() {
 }
 
 function cleanSearchResults() {
-  if (location.pathname.startsWith("/results")) {
+  if (location.pathname.startsWith('/results')) {
     // Mobile
-    const badges = document.querySelectorAll("ytm-badge");
-    badges.forEach((badge) => {
+    const badges = document.querySelectorAll('ytm-badge');
+    badges.forEach(badge => {
       // Only support Chinese and English now
-      if (
-        badge.innerText == "相關影片" ||
-        badge.innerText == "相关视频" ||
-        badge.innerText == "Related"
-      ) {
-        badge.closest("ytm-video-with-context-renderer")?.remove();
+      if (badge.innerText == '相關影片' || badge.innerText == '相关视频' || badge.innerText == 'Related') {
+        badge.closest('ytm-video-with-context-renderer')?.remove();
       }
     });
   }

--- a/main.user.js
+++ b/main.user.js
@@ -11,13 +11,13 @@
 
 /* Credit:  https://github.com/lawrencehook/remove-youtube-suggestions */
 
-'use strict';
+"use strict";
 
 // Config custom settings here
 const SETTINGS = {
   /// homepage redirect ///
   // redirectHomepage Options: 'wl', 'subs', 'lib', false
-  redirectHomepage: 'wl',
+  redirectHomepage: "wl",
   hideHomepage: true,
 
   /// video player ///
@@ -34,39 +34,41 @@ const SETTINGS = {
   /// misc ///
   hideSearchButton: false,
   cleanSearchResults: true,
+  hideComments: false,
+  hideNotifications: false,
 };
 
 // Mark settings in HTML
 const HTML = document.documentElement;
-Object.keys(SETTINGS).forEach(key => {
+Object.keys(SETTINGS).forEach((key) => {
   HTML.setAttribute(key, SETTINGS[key]);
 });
 
 // CSS selectors of elements to block
 const DESKTOP_BLOCK_LIST = [
-  // Ads 
-  '#masthead-ad',
-  'ytd-mealbar-promo-renderer',
-  'ytd-carousel-ad-renderer',
-  '.ytd-display-ad-renderer',
-  'ytd-ad-slot-renderer',
-  'div.ytp-ad-overlay-image',
-  '.iv-branding.annotation-type-custom.annotation',
+  // Ads
+  "#masthead-ad",
+  "ytd-mealbar-promo-renderer",
+  "ytd-carousel-ad-renderer",
+  ".ytd-display-ad-renderer",
+  "ytd-ad-slot-renderer",
+  "div.ytp-ad-overlay-image",
+  ".iv-branding.annotation-type-custom.annotation",
 
   // Shorts
   'html[hideShorts="true"] ytd-rich-section-renderer',
   'html[hideShorts="true"] ytd-reel-shelf-renderer',
   'html[hideShorts="true"] ytd-shelf-renderer',
 
-  // Left Bar Navigation 
+  // Left Bar Navigation
   'a[href="/feed/trending"]',
   'a[href="/feed/explore"]',
   'html[hideShorts="true"] ytd-guide-section-renderer a[title="Shorts"]',
   'html[hideShorts="true"] ytd-mini-guide-entry-renderer[aria-label="Shorts"]',
-  'ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(4)',
-  'ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(3)',
+  "ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(4)",
+  "ytd-guide-section-renderer.ytd-guide-renderer.style-scope:nth-of-type(3)",
 
-  // Homepage 
+  // Homepage
   'html[hideHomepage="true"] a:not(#logo)[href="/"]',
   'html[hideHomepage="true"] ytd-browse[page-subtype="home"]',
 
@@ -78,23 +80,25 @@ const DESKTOP_BLOCK_LIST = [
   'html[hidePlayNextButton="true"] a.ytp-prev-button.ytp-button',
   'html[hideLiveChat="true"] #chat',
   'html[hideMiniPlayerButton="true"] .ytp-button.ytp-miniplayer-button',
+  'html[hideComments="true"] ytd-comments#comments',
   // '#movie_player button.ytp-button.ytp-share-button',
   // '#movie_player button.ytp-button.ytp-watch-later-button',
-  '.ytd-download-button-renderer.style-scope',
+  ".ytd-download-button-renderer.style-scope",
 
   // Search
-  'div.sbdd_a',
-  '#container.ytd-search ytd-search-pyv-renderer',
+  "div.sbdd_a",
+  "#container.ytd-search ytd-search-pyv-renderer",
   'html[hideSearchButton="true"] div.ytd-masthead>ytd-searchbox',
   'html[hideSearchButton="true"] div.ytd-masthead>#voice-search-button',
+  'html[hideNotifications="true"] ytd-notification-topbar-button-renderer',
 ];
 
 const MOBILE_BLOCK_LIST = [
-  // Ads 
-  'ytm-companion-ad-renderer',
-  'ytm-promoted-sparkles-web-renderer',
+  // Ads
+  "ytm-companion-ad-renderer",
+  "ytm-promoted-sparkles-web-renderer",
 
-  // Homepage 
+  // Homepage
   'html[hideHomepage="true"] div[tab-identifier="FEwhat_to_watch"]',
   'html[hideSearchButton="true"] #header-bar > header > div > button',
   'html[hideSearchButton="true"] #center.style-scope.ytd-masthead',
@@ -102,26 +106,30 @@ const MOBILE_BLOCK_LIST = [
   // Shorts in search results
   'html[hideShorts="true"] ytm-reel-shelf-renderer.item',
 
-  // Video Player 
+  // Video Player
   'html[hideRelatedVideos="true"] ytm-item-section-renderer[section-identifier="related-items"]>lazy-list',
   'html[hidePlayNextButton="true"] .player-controls-middle-core-buttons > div:nth-child(1)',
   'html[hidePlayNextButton="true"] .player-controls-middle-core-buttons > div:nth-child(5)',
 
-  // Navigation Bar 
+  // Navigation Bar
   'html[hideHomepage="true"] ytm-pivot-bar-item-renderer:nth-child(1)',
   'html[hideShorts="true"] ytm-pivot-bar-item-renderer:nth-child(2)',
   'ytm-chip-cloud-chip-renderer[chip-style="STYLE_EXPLORE_LAUNCHER_CHIP"]',
 ];
 
 // Add CSS to block elements
-let css = '';
-if (location.hostname.startsWith('www.')) {
-  css = DESKTOP_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
+let css = "";
+if (location.hostname.startsWith("www.")) {
+  css = DESKTOP_BLOCK_LIST.map((e) => `${e} {display: none !important}`).join(
+    "\n",
+  );
 }
-if (location.hostname.startsWith('m.')) {
-  css = MOBILE_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
+if (location.hostname.startsWith("m.")) {
+  css = MOBILE_BLOCK_LIST.map((e) => `${e} {display: none !important}`).join(
+    "\n",
+  );
 }
-const style = document.createElement('style');
+const style = document.createElement("style");
 style.textContent = css;
 document.head.appendChild(style);
 
@@ -130,7 +138,6 @@ let lastUrl = null;
 
 // Start running dynamic settings
 runDynamicSettings();
-
 
 ///// Dynamic Settings Functions /////
 
@@ -153,37 +160,41 @@ function runDynamicSettings() {
 }
 
 function redirectHomepage() {
-  if (location.pathname == '/') {
-    if (SETTINGS.redirectHomepage == 'wl') {
-      location.replace('/playlist/?list=WL');
+  if (location.pathname == "/") {
+    if (SETTINGS.redirectHomepage == "wl") {
+      location.replace("/playlist/?list=WL");
     }
-    if (SETTINGS.redirectHomepage == 'subs') {
-      location.replace('/feed/subscriptions');
+    if (SETTINGS.redirectHomepage == "subs") {
+      location.replace("/feed/subscriptions");
     }
-    if (SETTINGS.redirectHomepage == 'lib') {
-      location.replace('/feed/library');
+    if (SETTINGS.redirectHomepage == "lib") {
+      location.replace("/feed/library");
     }
   }
 }
 
 function redirectShortsPlayer() {
-  if (location.pathname.startsWith('/shorts')) {
-    const redirPath = location.pathname.replace('shorts', 'watch');
+  if (location.pathname.startsWith("/shorts")) {
+    const redirPath = location.pathname.replace("shorts", "watch");
     location.replace(redirPath);
   }
 }
 
 function disableRelatedAutoPlay() {
   // turn off auto play button
-  const autoplayButton = document.querySelectorAll('.ytp-autonav-toggle-button[aria-checked=true]');
-  autoplayButton?.forEach(e => {
+  const autoplayButton = document.querySelectorAll(
+    ".ytp-autonav-toggle-button[aria-checked=true]",
+  );
+  autoplayButton?.forEach((e) => {
     if (e && e.offsetParent) {
       e.click();
     }
   });
   // turn off auto play button on mobile
-  const mAutoplayButton = document.querySelectorAll('.ytm-autonav-toggle-button-container[aria-pressed=true]');
-  mAutoplayButton?.forEach(e => {
+  const mAutoplayButton = document.querySelectorAll(
+    ".ytm-autonav-toggle-button-container[aria-pressed=true]",
+  );
+  mAutoplayButton?.forEach((e) => {
     if (e && e.offsetParent) {
       e.click();
     }
@@ -192,45 +203,47 @@ function disableRelatedAutoPlay() {
 
 function hideShortsVideos() {
   const shortsLinks = document.querySelectorAll('a[href^="/shorts"]');
-  if (location.pathname == '/feed/subscriptions') {
-    shortsLinks.forEach(link => {
+  if (location.pathname == "/feed/subscriptions") {
+    shortsLinks.forEach((link) => {
       // For desktop
-      link.closest('ytd-video-renderer')?.remove();
+      link.closest("ytd-video-renderer")?.remove();
       // For mobile
-      link.closest('ytm-item-section-renderer')?.remove();
+      link.closest("ytm-item-section-renderer")?.remove();
     });
   }
   // Hide shorts on search result pages
-  if (location.pathname.startsWith('/results')) {
-    shortsLinks.forEach(link => {
+  if (location.pathname.startsWith("/results")) {
+    shortsLinks.forEach((link) => {
       // For desktop
-      link.closest('ytd-video-renderer')?.remove();
+      link.closest("ytd-video-renderer")?.remove();
       // For mobile
-      link.closest('ytm-video-with-context-renderer')?.remove();
+      link.closest("ytm-video-with-context-renderer")?.remove();
     });
   }
   // Hide the "shorts" tab on channel page
-  if (location.pathname.startsWith('/@')) {
-    document.querySelectorAll('div.tab-content')?.forEach(tab => {
+  if (location.pathname.startsWith("/@")) {
+    document.querySelectorAll("div.tab-content")?.forEach((tab) => {
       if (tab.innerText == "SHORTS") tab.parentElement.remove(); // desktop
     });
-    document.querySelectorAll('a[role="tab"]')?.forEach(tab => {
-      if (tab.innerText == 'SHORTS') tab.remove(); // mobile
+    document.querySelectorAll('a[role="tab"]')?.forEach((tab) => {
+      if (tab.innerText == "SHORTS") tab.remove(); // mobile
     });
   }
 }
 
 function skipVideoAds() {
-  if (location.pathname.startsWith('/watch')) {
+  if (location.pathname.startsWith("/watch")) {
     // click "skip ad" button if it exists
     // during the first 5s, th button is not clickable in UI, but it's clickable in console
-    const adSkipButton = document.querySelector(".ytp-ad-skip-button-slot button,.ytp-ad-overlay-close-button");
+    const adSkipButton = document.querySelector(
+      ".ytp-ad-skip-button-slot button,.ytp-ad-overlay-close-button",
+    );
     adSkipButton?.click();
 
     // skip ad video
-    const adVideo = document.querySelector('.ad-showing');
+    const adVideo = document.querySelector(".ad-showing");
     if (adVideo) {
-      const video = document.querySelector('.html5-main-video');
+      const video = document.querySelector(".html5-main-video");
       if (video && !isNaN(video?.duration)) {
         video.play();
         video.currentTime = video?.duration;
@@ -240,13 +253,17 @@ function skipVideoAds() {
 }
 
 function cleanSearchResults() {
-  if (location.pathname.startsWith('/results')) {
+  if (location.pathname.startsWith("/results")) {
     // Mobile
-    const badges = document.querySelectorAll('ytm-badge');
-    badges.forEach(badge => {
+    const badges = document.querySelectorAll("ytm-badge");
+    badges.forEach((badge) => {
       // Only support Chinese and English now
-      if (badge.innerText == '相關影片' || badge.innerText == '相关视频' || badge.innerText == 'Related') {
-        badge.closest('ytm-video-with-context-renderer')?.remove();
+      if (
+        badge.innerText == "相關影片" ||
+        badge.innerText == "相关视频" ||
+        badge.innerText == "Related"
+      ) {
+        badge.closest("ytm-video-with-context-renderer")?.remove();
       }
     });
   }


### PR DESCRIPTION
**What**
Adds two new settings flags: hideComments and hideNotifications, both defaulting to false.

**Why**
Gives users more control over UI clutter without changing existing behaviour by default.

**Notes**
No breaking changes. Defaults keep current behaviour.