### PR TITLE
Fix for "Cannot read properties of null" error

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -114,16 +114,19 @@ const MOBILE_BLOCK_LIST = [
 ];
 
 // Add CSS to block elements
-let css = '';
-if (location.hostname.startsWith('www.')) {
-  css = DESKTOP_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
-}
-if (location.hostname.startsWith('m.')) {
-  css = MOBILE_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
-}
-const style = document.createElement('style');
-style.textContent = css;
-document.head.appendChild(style);
+document.addEventListener('DOMContentLoaded', evt => { // Ivan-Khar: Fixes "document.head is null" error
+  let css = '';
+  if (location.hostname.startsWith('www.')) {
+    css = DESKTOP_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
+  }
+  if (location.hostname.startsWith('m.')) {
+    css = MOBILE_BLOCK_LIST.map(e => `${e} {display: none !important}`).join('\n');
+  }
+  const style = document.createElement('style');
+  style.textContent = css;
+
+  document.head.appendChild(style);
+});
 
 // Track last processed URL
 let lastUrl = null;


### PR DESCRIPTION
For some reason this userscript throws `Cannot read properties of null (reading 'appendChild')` error on my machines with Firefox/Brave + ViolentMonkey installed. This pr fixes this error by applying css customizations in [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event) event instead of applying them on script load

Havent tested it with Tampermonkey but it *should work*. Needs testing
<img width="621" height="89" alt="image" src="https://github.com/user-attachments/assets/8c0fb587-ccb0-49ce-9371-51d8c49802ca" />

